### PR TITLE
setHeader before sending to target

### DIFF
--- a/bin/proxy-server/proxy.js
+++ b/bin/proxy-server/proxy.js
@@ -28,7 +28,7 @@ module.exports = function(config) {
         head: [ brownieMeta ],
         body: [ wabScript ]
     });
-    
+
     // define the proxies
     endpoints.forEach(function(item) {
         const proxy = httpProxy.createProxyServer({ target: item.source, ws: true });
@@ -38,6 +38,7 @@ module.exports = function(config) {
                 res.status(500);
                 res.set('content-type', 'text/plain');
                 res.send('Internal server error');
+                res.setHeader('Host', extract_hostname(item.source));
             } else {
                 res.end();
             }


### PR DESCRIPTION
virtual wab_src that require http/1.1 (such as s3 website endpoints) need the host set in the header:
```
T 172.18.0.1:47460 -> 172.18.0.2:9000 [AP]
  GET / HTTP/1.1..Host: 172.18.0.2:9000..User-Agent: curl/7.47.0..Accept: */*....                                                                                        
##
U 172.18.0.2:52954 -> 8.8.8.8:53
  A0...........wabsng-s3.autoreg.byu.edu.s3-website-us-west-2.amazonaws.com.....                                                                                         
#
U 172.18.0.2:52954 -> 8.8.8.8:53
  )............wabsng-s3.autoreg.byu.edu.s3-website-us-west-2.amazonaws.com.....                                                                                         
#
U 8.8.8.8:53 -> 172.18.0.2:52954
  A0...........wabsng-s3.autoreg.byu.edu.s3-website-us-west-2.amazonaws.com..............3...&.&.........E.ns-928.awsdns-52.net..awsdns-hostmaster.amazon.E....... ......
  u...Q.                                                                                                                                                                 
#
U 8.8.8.8:53 -> 172.18.0.2:52954
  )............wabsng-s3.autoreg.byu.edu.s3-website-us-west-2.amazonaws.com..............3...&.&..........6...                                                           
####
T 172.18.0.2:51686 -> 54.231.176.251:80 [AP]
  GET / HTTP/1.1..accept: */*..user-agent: curl/7.47.0..host: 172.18.0.2:9000..connection: close....                                                                     
##
T 54.231.176.251:80 -> 172.18.0.2:51686 [AP]
  HTTP/1.1 301 Moved Permanently..x-amz-error-code: WebsiteRedirect..x-amz-error-message: Request does not contain a bucket name...x-amz-request-id: 6920FBA757C97A5C..x-
  amz-id-2: xDSTw2oV3c4LZStkl76XCdphPDkYezff6gipEiZXmTU89rvNDHiTv8CKc5G6spS59JFBN0ku3pA=..Location: https://aws.amazon.com/s3/..Content-Type: text/html; charset=utf-8..C
ontent-Length: 348..Date: Tue, 02 Aug 2016 02:15:39 GMT..Server: AmazonS3..Connection: close.... 
```

This PR closes #6 and is as per [http-proxy](https://www.npmjs.com/package/http-proxy#setup-a-stand-alone-proxy-server-with-proxy-request-header-re-writing).